### PR TITLE
Testing improvements

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -43,6 +43,36 @@ final class Result
         }
     }
 
+    /**
+     * Create instance representing a success.
+     */
+    public static function success(?\DateTimeImmutable $challengeTime = null, ?string $hostname = null): self
+    {
+        return new self(
+            true,
+            [],
+            $challengeTime,
+            $hostname,
+        );
+    }
+
+    /**
+     * Create instance representing a failure.
+     *
+     * @param list<ErrorCode>&non-empty-array $errorCodes
+     */
+    public static function failure(array $errorCodes, ?\DateTimeImmutable $challengeTime = null, ?string $hostname = null): self
+    {
+        Assert::minCount($errorCodes, 1);
+
+        return new self(
+            false,
+            $errorCodes,
+            $challengeTime,
+            $hostname,
+        );
+    }
+
     public static function fromJson(string $json): self
     {
         try {

--- a/src/TestClient.php
+++ b/src/TestClient.php
@@ -76,6 +76,9 @@ final class TestClient implements ClientInterface
             return $this->seen[$response];
         }
 
-        throw new \RuntimeException('No response found');
+        throw new \RuntimeException(sprintf(
+            'No result found for response `%s`',
+            $response,
+        ));
     }
 }


### PR DESCRIPTION
Realised shortcuts to create `Result` objects when writing tests for integration code is useful.

```php
new Result(true, [], null, null)
// becomes
Result::success()
```