### PR TITLE
Lock PHP version to minimum supported for dev tools

### DIFF
--- a/vendor-bin/cs/composer.json
+++ b/vendor-bin/cs/composer.json
@@ -2,5 +2,11 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.64",
         "staabm/annotate-pull-request-from-checkstyle": "^1.8"
+    },
+    "config": {
+        "platform": {
+            "php": "8.1.0",
+            "php-64bit": "8.1.0"
+        }
     }
 }

--- a/vendor-bin/cs/composer.lock
+++ b/vendor-bin/cs/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "560aced843b9eae7202477f573caad0d",
+    "content-hash": "e7935731880fb916af93fdf2f555a417",
     "packages": [],
     "packages-dev": [
         {
@@ -2679,10 +2679,14 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.1.0",
+        "php-64bit": "8.1.0"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -9,6 +9,10 @@
     "config": {
         "allow-plugins": {
             "phpstan/extension-installer": true
+        },
+        "platform": {
+            "php": "8.1.0",
+            "php-64bit": "8.1.0"
         }
     }
 }

--- a/vendor-bin/phpstan/composer.lock
+++ b/vendor-bin/phpstan/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a48084ad39881a194b0b24c67d1559b",
+    "content-hash": "cb26b0bee39f63ecb1ccfe812e702c06",
     "packages": [],
     "packages-dev": [
         {
@@ -269,10 +269,14 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.1.0",
+        "php-64bit": "8.1.0"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/vendor-bin/phpunit/composer.json
+++ b/vendor-bin/phpunit/composer.json
@@ -1,5 +1,11 @@
 {
     "require-dev": {
         "phpunit/phpunit": "^10.5"
+    },
+    "config": {
+        "platform": {
+            "php": "8.1.0",
+            "php-64bit": "8.1.0"
+        }
     }
 }

--- a/vendor-bin/phpunit/composer.lock
+++ b/vendor-bin/phpunit/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edf908e1f6b0e4fca8854163be177e40",
+    "content-hash": "defdbcce123e909c48097a430d0713a8",
     "packages": [],
     "packages-dev": [
         {
@@ -1639,5 +1639,9 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.1.0",
+        "php-64bit": "8.1.0"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This should allow dependabot to correctly update things.
